### PR TITLE
fix: crawl only /en and /cn

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,5 +2,7 @@ User-agent: facebookexternalhit
 Disallow:
 
 User-agent: *
-Allow: /
-Disallow: /api 
+Disallow: /
+Allow: /en
+Allow: /cn
+Disallow: /api


### PR DESCRIPTION
# Summary of the changes

<!-- highlight the main point of the proposed changes -->

1. Disable crawling for / and add crawling for /en and /cn
2.
3.

---


## Screenshots / Videos / Examples

<!-- insert app screenshots here -->

Some links or references here

---

## Need review from

<!-- insert the person you wish to mention here -->
<!-- eg: @mentionPersonA -->
